### PR TITLE
Fix #18: Avoid excessive velocities by limiting exponential gravity.

### DIFF
--- a/src/main/java/mchorse/vanilla_pack/morphs/IronGolemMorph.java
+++ b/src/main/java/mchorse/vanilla_pack/morphs/IronGolemMorph.java
@@ -26,7 +26,10 @@ public class IronGolemMorph extends EntityMorph
             target.motionX *= 0.5;
             target.motionZ *= 0.5;
 
-            target.motionY *= 1.3;
+            if (target.motionY > -5)
+            {
+                target.motionY *= (1.1 + target.motionY / 50.0);
+            }
         }
 
         super.update(target, cap);


### PR DESCRIPTION
The original implementation used unbounded exponential gravity, which could cause players to experience insane lag or even get kicked or crash due to the huge velocities involved after just a few seconds to minutes.

The new implementation reduces the strength of the exponential gravity as well as makes it taper off the faster you go downwards, thereby allowing for some exponential gravity without making it go too out of control with the velocities.